### PR TITLE
Fixed section images on mobile

### DIFF
--- a/layout.css
+++ b/layout.css
@@ -18,6 +18,11 @@ html, body {
     padding-top: 0.30263158em;
     padding-bottom: 0.60526316em;
 }
+
+.sectionimage img {
+    max-width: 100%;
+}
+
 .subsection {
     background-color: #000;
 }


### PR DESCRIPTION
Before:
<img width="358" alt="Screenshot 2021-05-18 at 09 51 00" src="https://user-images.githubusercontent.com/9111/118605143-9d8f1000-b7be-11eb-9972-f290687354d9.png">


After:
<img width="356" alt="Screenshot 2021-05-18 at 09 51 12" src="https://user-images.githubusercontent.com/9111/118605151-a1229700-b7be-11eb-9fa2-f9a455a890c0.png">


You're welcome.
